### PR TITLE
feat: support QoS settings for rviz2_overlay_plugins

### DIFF
--- a/rviz2_plugins/rviz2_overlay_plugins/src/image_overlay_display.hpp
+++ b/rviz2_plugins/rviz2_overlay_plugins/src/image_overlay_display.hpp
@@ -17,6 +17,7 @@
 
 #include <memory>
 #include <mutex>
+#include <rclcpp/qos.hpp>
 
 #ifndef Q_MOC_RUN
 #include "jsk_overlay_utils.hpp"
@@ -25,7 +26,11 @@
 #include <rviz_common/properties/color_property.hpp>
 #include <rviz_common/properties/float_property.hpp>
 #include <rviz_common/properties/int_property.hpp>
+#include <rviz_common/properties/enum_property.hpp>
+#include <rviz_common/properties/editable_enum_property.hpp>
 #include <rviz_common/ros_topic_display.hpp>
+#include <image_transport/subscriber_filter.h>
+#include <message_filters/subscriber.h>
 #endif
 
 namespace rviz_plugins
@@ -46,6 +51,7 @@ public:
 
 private Q_SLOTS:
   void updateVisualization();
+  void updateQoS();
 
 protected:
   void update(float wall_dt, float ros_dt) override;
@@ -58,11 +64,13 @@ protected:
   rviz_common::properties::StringProperty * property_topic_name_;
   rviz_common::properties::FloatProperty * property_alpha_;
   rviz_common::properties::BoolProperty * property_image_type_;
+  rviz_common::properties::EnumProperty * property_qos_reliability_;
+  rviz_common::properties::EnumProperty * property_qos_durability_;
+  rclcpp::QoS custom_qos_profile_;
 
 private:
-  std::shared_ptr<image_transport::ImageTransport> it_;
-  std::shared_ptr<image_transport::Subscriber> sub_;
   sensor_msgs::msg::Image::ConstSharedPtr last_msg_ptr_;
+  rclcpp::Subscription<sensor_msgs::msg::Image>::SharedPtr sub_;
   std::string topic_name_;
   bool update_required_ = true;
 };


### PR DESCRIPTION
I want to add a setting for QoS in rviz2_overlay_plugins
![image](https://user-images.githubusercontent.com/44218668/231352860-38134a8d-695d-408f-a3c5-b48a84730f63.png)

Drawbacks:
- It does not use `image_transport` any longer, and thus cannot subscribe compressed image directly. This is because I couldn't find a way to change QoS settings for the subscriber from `image_transport` (e.g. from [here](https://github.com/ros-perception/image_common/blob/9669ada76c0996c831bb8269ff22f08ada1b5c88/image_transport/src/image_transport.cpp#L152-L164))