### PR TITLE
fix(mpf): catch runtime_error when particle id is invalid

### DIFF
--- a/particle_filter/modularized_particle_filter/include/modularized_particle_filter/prediction/resampler.hpp
+++ b/particle_filter/modularized_particle_filter/include/modularized_particle_filter/prediction/resampler.hpp
@@ -23,6 +23,12 @@
 
 namespace yabloc::modularized_particle_filter
 {
+class resampling_skip_exception : public std::runtime_error
+{
+public:
+  resampling_skip_exception(const char * message) : runtime_error(message) {}
+};
+
 class RetroactiveResampler
 {
 public:

--- a/particle_filter/modularized_particle_filter/src/prediction/resampler.cpp
+++ b/particle_filter/modularized_particle_filter/src/prediction/resampler.cpp
@@ -65,7 +65,7 @@ RetroactiveResampler::ParticleArray RetroactiveResampler::add_weight_retroactive
 {
   if (!check_weighted_particles_validity(weighted_particles)) {
     RCLCPP_ERROR_STREAM(logger_, "weighted_particles has invalid data");
-    throw std::runtime_error("weighted_particles has invalid data");
+    throw resampling_skip_exception("weighted_particles has invalid data");
   }
 
   // Initialize corresponding index lookup table


### PR DESCRIPTION
Each time the particle filter is initialized, the particle id resets to 0.Until nowDuring processing
Previously, an exception was thrown because the id of the weighted particle being processed was invalid.
Now, exceptions thrown at this time are caught.