### PR TITLE
fix path search error in build stage

### DIFF
--- a/particle_filter/gnss_particle_corrector/CMakeLists.txt
+++ b/particle_filter/gnss_particle_corrector/CMakeLists.txt
@@ -26,7 +26,7 @@ find_package(Sophus REQUIRED)
 # GeographicLib
 find_package(PkgConfig)
 find_path(GeographicLib_INCLUDE_DIR GeographicLib/Config.h
-  PAHT_SUFFIXES GeographicLib
+  PATH_SUFFIXES GeographicLib
 )
 set(GeographicLib_INCLUDE_DIRS ${GeographicLib_INCLUDE_DIR})
 find_library(GeographicLib_LIBRARIES NAMES Geographic)

--- a/unstable/ekf/gnss_ekf_corrector/CMakeLists.txt
+++ b/unstable/ekf/gnss_ekf_corrector/CMakeLists.txt
@@ -26,7 +26,7 @@ find_package(Sophus REQUIRED)
 # GeographicLib
 find_package(PkgConfig)
 find_path(GeographicLib_INCLUDE_DIR GeographicLib/Config.h
-  PAHT_SUFFIXES GeographicLib
+  PATH_SUFFIXES GeographicLib
 )
 set(GeographicLib_INCLUDE_DIRS ${GeographicLib_INCLUDE_DIR})
 find_library(GeographicLib_LIBRARIES NAMES Geographic)

--- a/yabloc_common/CMakeLists.txt
+++ b/yabloc_common/CMakeLists.txt
@@ -32,7 +32,7 @@ find_package(Sophus REQUIRED)
 # GeographicLib
 find_package(PkgConfig)
 find_path(GeographicLib_INCLUDE_DIR GeographicLib/Config.h
-  PAHT_SUFFIXES GeographicLib
+  PATH_SUFFIXES GeographicLib
 )
 set(GeographicLib_INCLUDE_DIRS ${GeographicLib_INCLUDE_DIR})
 find_library(GeographicLib_LIBRARIES NAMES Geographic)


### PR DESCRIPTION
Fix the typo that caused the `colcon build` failure.

(Apart from this, `apt install libgeographic-dev` was required to build. fiy)

Thanks